### PR TITLE
feat/기계공학부

### DIFF
--- a/type-a/ee.ts
+++ b/type-a/ee.ts
@@ -35,7 +35,7 @@ export async function getEeUrlList(
 }
 
 /**
- * @param url getEngUrlList 함수에서 반환된 url 하나
+ * @param url getEeUrlList 함수에서 반환된 url 하나
  * @param mainCategory 탐색중인 카테고리 번호, 1: 학부, 2: 대학원, 3: 취업정보
  * @returns 공지사항의 제목, 작성자, 게시일자, public URL, HTML table body, 카테고리 내용을 반환합니다.
  */

--- a/type-a/me.ts
+++ b/type-a/me.ts
@@ -22,7 +22,7 @@ export async function getMeUrlList(
   listnum: number,
   category: MeCategory,
 ): Promise<string[]> {
-  const meCategory = (category != 3) ? "undernotice" : "job";
+  const meCategory = (category != MeCategory.Job) ? "undernotice" : "job";
   if (!meCategory) throw Error("Invalid category number");
   const mainUrl = (category != 3)
     ? `https://me.korea.ac.kr/community/undernotice.html?cate%5B%5D=${category}&listnum=${listnum}`

--- a/type-a/me.ts
+++ b/type-a/me.ts
@@ -1,0 +1,67 @@
+import {
+  convertRelativeFilePath,
+  fetchWithError,
+  getTypeAUrlList,
+  parseArticle,
+  type TypeANotice,
+} from "./type-a.ts";
+
+enum MeCategory {
+  UnderAndGrad = 0,
+  Undergraduate = 1,
+  Graduate = 2,
+  Job = 3,
+}
+
+/**
+ * @param listnum 탐색할 게시글 개수 최대치
+ * @param category 탐색할 카테고리 번호, 0: 일반(학부 및 대학원, 취업정보는 해당없음), 1: 학부, 2: 대학원, 3: 취업정보
+ * @returns 해당 페이지의 공지사항 URL 리스트를 반환합니다.
+ */
+export async function getMeUrlList(
+  listnum: number,
+  category: MeCategory,
+): Promise<string[]> {
+  const meCategory = (category != 3) ? "undernotice" : "job";
+  if (!meCategory) throw Error("Invalid category number");
+  const mainUrl = (category != 3)
+    ? `https://me.korea.ac.kr/community/undernotice.html?cate%5B%5D=${category}&listnum=${listnum}`
+    : `https://me.korea.ac.kr/community/job.html?listnum=${listnum}`;
+
+  const hrefList = await getTypeAUrlList(mainUrl, `${meCategory}_view`);
+  return hrefList.map((x) => "https://me.korea.ac.kr/community/" + x);
+}
+
+/**
+ * @param url getMeUrlList 함수에서 반환된 url 하나
+ * @param mainCategory 탐색중인 카테고리 번호, 0: 일반(학부 및 대학원, 취업정보는 해당없음), 1: 학부, 2: 대학원, 3: 취업정보
+ * @returns 공지사항의 제목, 작성자, 게시일자, public URL, HTML table body, 카테고리 내용을 반환합니다.
+ */
+//이 함수를 부를 때 순서는 1,2->0,3 추천. 일반은 취업정보 제외한 모든 게시글을 불러오기 때문.
+export async function getNoticeFromMe(
+  url: string,
+  mainCategory: MeCategory,
+): Promise<TypeANotice> {
+  const scrap = await fetchWithError(url);
+  const html = await scrap.text();
+  const article = convertRelativeFilePath(html, "https://me.korea.ac.kr");
+
+  const noticeData = parseArticle(article, { title: "div", date: "p" });
+  noticeData.url = url;
+
+  const subcategory = {
+    0: "일반",
+    1: "학부",
+    2: "대학원",
+    3: "취업정보",
+  }[mainCategory];
+  if (!subcategory) throw Error("Invalid category number");
+
+  noticeData.writer = subcategory;
+  //기계공학부는 writer데이터가 없다
+
+  noticeData.category = subcategory +
+    (noticeData.title.includes("장학") ? " 장학" : " 공지");
+
+  return noticeData;
+}

--- a/type-a/me.ts
+++ b/type-a/me.ts
@@ -36,8 +36,8 @@ export async function getMeUrlList(
  * @param url getMeUrlList 함수에서 반환된 url 하나
  * @param mainCategory 탐색중인 카테고리 번호, 0: 일반(학부 및 대학원, 취업정보는 해당없음), 1: 학부, 2: 대학원, 3: 취업정보
  * @returns 공지사항의 제목, 작성자, 게시일자, public URL, HTML table body, 카테고리 내용을 반환합니다.
+ * 이 함수를 부를 때 순서는 1,2->0,3 추천. 일반은 취업정보 제외한 모든 게시글을 불러와 카테고리 구분이 안되기 때문.
  */
-//이 함수를 부를 때 순서는 1,2->0,3 추천. 일반은 취업정보 제외한 모든 게시글을 불러오기 때문.
 export async function getNoticeFromMe(
   url: string,
   mainCategory: MeCategory,
@@ -57,8 +57,8 @@ export async function getNoticeFromMe(
   }[mainCategory];
   if (!subcategory) throw Error("Invalid category number");
 
-  noticeData.writer = subcategory;
-  //기계공학부는 writer데이터가 없다
+  noticeData.writer = "기계공학부";
+  //기계공학부는 writer데이터가 없어서 통일
 
   noticeData.category = subcategory +
     (noticeData.title.includes("장학") ? " 장학" : " 공지");


### PR DESCRIPTION
type-a의 기계공학부 추가하였습니다.
경영대학이나 전기전자와 다른 점은

1.UrlList를 가져다 주는 함수가 페이지번호가 아닌 탐색할 게시글 개수 최대치인 listnum을 받습니다.

2.기계공학부 공지는 작성자 정보가 없어 subcategory로 대체하였습니다.

3.기계공학부 공지의 경우 23년 10월 이후 학부/대학원 카테고리가 웬만하면 명확하게 분류되지만, 그 전 공지사항의 경우, 또는 간혹 둘 다 아닌 공지와 같이 분류되지 않은 공지만 불러올 수단이 없습니다. 따라서 필요한 경우 해당 데이터들을 불러올 수는 있도록 하기 위해 전체 카테고리(enum MeCategory에서 UnderAndGrad = 0)를 넣었으며, 해당 카테고리로 불러오는 게시글은 학부나 대학원과 겹치는 공지들이 존재하므로 상위 함수에서 불러올 시 그런 게시글들을 제외하고 불러오는 기능이 필요합니다.